### PR TITLE
Update project URL and improve README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,3 +2,38 @@ colcon-alias
 ============
 
 An extension for `colcon-core <https://github.com/colcon/colcon-core>`_ to create and modify command aliases.
+
+Aliases condense any number of colcon command invocations made up of a verb followed by all associated arguments down to another 'alias' verb. When invoking the alias verb, additional arguments can be appended to the original invocations.
+
+An example alias called 'bat', short for 'build and test'::
+
+    $ colcon alias bat --command build --command test
+    Registered command list for alias 'bat':
+      build
+      test
+    $ colcon bat --packages-select colcon-alias
+    Running command alias: colcon build --packages-select colcon-alias
+    ...
+    Running command alias: colcon test --packages-select colcon-alias
+    ...
+
+Another example, an alias for building specific packages::
+
+    $ colcon alias buildpkg --command build --event-handler console_direct+ --packages-select
+    Registered command list for alias 'buildpkg':
+      build --event-handler console_direct+ --packages-select
+    $ colcon buildpkg colcon-alias
+    Running command alias: colcon build --event-handler console_direct+ --packages-select colcon-alias
+    ...
+
+A list of currently registered aliases can be found in the colcon help text::
+
+    $ colcon --help
+    ...
+
+    colcon aliases:
+      bat                   build
+                            test
+      buildpkg              build --event-handler console_direct+ --packages-select
+
+    ...

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [metadata]
 name = colcon-alias
 version = attr: colcon_alias.__version__
-url = https://colcon.readthedocs.io
+url = https://github.com/colcon/colcon-alias/
 project_urls =
     Changelog = https://github.com/colcon/colcon-alias/milestones?direction=desc&sort=due_date&state=closed
     GitHub = https://github.com/colcon/colcon-alias/


### PR DESCRIPTION
During Fedora package review, it was pointed out that this extension isn't mentioned at all on https://colcon.readthedocs.io, and making things worse, the project's README made the package's purpose about as clear as mud.