### PR TITLE
Require Python 3.6, switch to using f-strings

### DIFF
--- a/colcon_alias/argument_parser/alias.py
+++ b/colcon_alias/argument_parser/alias.py
@@ -62,13 +62,13 @@ class AliasArgumentDecorator(ArgumentParserDecorator):
             command_strings = [' '.join(c) for c in commands]
 
             commands_ind = ('\n' + ' ' * 24).join(command_strings)
-            aliases.append('  {alias:21} {commands_ind}'.format_map(locals()))
+            aliases.append(f'  {alias:21} {commands_ind}')
 
             commands_ind = '\n  '.join(command_strings)
             alias_parser = self._subparser.add_parser(
                 alias, add_help=False,
                 description='This is an alias for the following command(s):\n'
-                            '  {commands_ind}'.format_map(locals()),
+                            f'  {commands_ind}',
                 formatter_class=self._parser.formatter_class)
 
             extension = AliasInvocationVerb(commands)

--- a/colcon_alias/config.py
+++ b/colcon_alias/config.py
@@ -15,7 +15,7 @@ def get_config():
     config_path = get_config_path()
     config_path.mkdir(parents=True, exist_ok=True)
     config_file = config_path / CONFIG_NAME
-    lock_file = config_path / '.{}.lock'.format(CONFIG_NAME)
+    lock_file = config_path / f'.{CONFIG_NAME}.lock'
     try:
         with filelock.FileLock(lock_file, timeout=5):
             with config_file.open() as f:
@@ -31,7 +31,7 @@ def update_config(alias_name, commands):
     config_path = get_config_path()
     config_path.mkdir(parents=True, exist_ok=True)
     config_file = config_path / CONFIG_NAME
-    lock_file = config_path / '.{}.lock'.format(CONFIG_NAME)
+    lock_file = config_path / f'.{CONFIG_NAME}.lock'
     with filelock.FileLock(lock_file, timeout=5):
         with config_file.open('a+') as f:
             f.seek(0)

--- a/colcon_alias/verb/alias.py
+++ b/colcon_alias/verb/alias.py
@@ -25,12 +25,10 @@ class AliasVerb(VerbExtensionPoint):
     def main(self, *, context):  # noqa: D102
         update_config(context.args.alias_name, context.args.command)
         if not context.args.command:
-            print(
-                "Alias '{context.args.alias_name}' has "
-                'been removed.'.format_map(locals()))
+            print(f"Alias '{context.args.alias_name}' has been removed.")
         else:
             print(
                 'Registered command list for alias '
-                "'{context.args.alias_name}':".format_map(locals()))
+                f"'{context.args.alias_name}':")
             for command in context.args.command:
-                print('  {}'.format(' '.join(command)))
+                print(f"  {' '.join(command)}")

--- a/colcon_alias/verb/alias_invocation.py
+++ b/colcon_alias/verb/alias_invocation.py
@@ -44,8 +44,8 @@ class AliasInvocationVerb(VerbExtensionPoint):
         for command in self._commands:
             argv = command + context.args.additional_args
             print(
-                'Running command alias: {} {}'.format(
-                    context.command_name, ' '.join(argv)))
+                f'Running command alias: {context.command_name} '
+                f"{' '.join(argv)}")
 
             with SuppressUsageOutput([parser] + list(verb_parsers.values())):
                 known_args, _ = parser.parse_known_args(args=argv)

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,6 +24,7 @@ long_description = file: README.rst
 keywords = colcon
 
 [options]
+python_requires = >=3.6
 install_requires =
   colcon-core
   filelock

--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -3,4 +3,4 @@ No-Python2:
 Depends3: python3-colcon-core, python3-filelock, python3-yaml
 Conflicts3: python3-colcon-mixin (< 0.2.2)
 Suite: bionic focal jammy stretch buster bullseye
-X-Python3-Version: >= 3.5
+X-Python3-Version: >= 3.6

--- a/test/test_flake8.py
+++ b/test/test_flake8.py
@@ -43,9 +43,6 @@ def test_flake8():
         if report_tests.total_errors:
             report_tests._application.formatter.show_statistics(
                 report_tests._stats)
-        print(
-            'flake8 reported {total_errors} errors'
-            .format_map(locals()), file=sys.stderr)
+        print(f'flake8 reported {total_errors} errors', file=sys.stderr)
 
-    assert not total_errors, \
-        'flake8 reported {total_errors} errors'.format_map(locals())
+    assert not total_errors, f'flake8 reported {total_errors} errors'

--- a/test/test_spell_check.py
+++ b/test/test_spell_check.py
@@ -36,14 +36,14 @@ def test_spell_check(known_words):
 
     unknown_word_count = len(report.unknown_words)
     assert unknown_word_count == 0, \
-        'Found {unknown_word_count} unknown words: '.format_map(locals()) + \
+        f'Found {unknown_word_count} unknown words: ' + \
         ', '.join(sorted(report.unknown_words))
 
     unused_known_words = set(known_words) - report.found_known_words
     unused_known_word_count = len(unused_known_words)
     assert unused_known_word_count == 0, \
-        '{unused_known_word_count} words in the word list are not used: ' \
-        .format_map(locals()) + ', '.join(sorted(unused_known_words))
+        f'{unused_known_word_count} words in the word list are not used: ' + \
+        ', '.join(sorted(unused_known_words))
 
 
 def test_spell_check_word_list_order(known_words):


### PR DESCRIPTION
This change has already been made in several other colcon extensions.