### PR TITLE
Block injection of mixin arguments on 'alias' verb

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -37,3 +37,5 @@ A list of currently registered aliases can be found in the colcon help text::
       buildpkg              build --event-handler console_direct+ --packages-select
 
     ...
+
+Note: When using ``colcon-alias`` with the ``colcon-mixin`` extension, the ``--mixin`` command line argument is applied as an argument to ``--command`` and not used as an actual mixin to the ``alias`` verb.

--- a/colcon_alias/argument_parser/alias.py
+++ b/colcon_alias/argument_parser/alias.py
@@ -8,6 +8,13 @@ from colcon_core.argument_parser import ArgumentParserDecoratorExtensionPoint
 from colcon_core.argument_parser import logger
 from colcon_core.plugin_system import satisfies_version
 
+try:
+    from colcon_mixin.mixin.mixin_argument import VERB_BLOCKLIST
+except ImportError:
+    pass
+else:
+    VERB_BLOCKLIST.add(('alias', ))
+
 
 class AliasArgumentParserDecorator(ArgumentParserDecoratorExtensionPoint):
     """Add command aliases verbs to the argument parser."""

--- a/test/spell_check.words
+++ b/test/spell_check.words
@@ -1,4 +1,5 @@
 apache
+blocklist
 chdir
 colcon
 filelock


### PR DESCRIPTION
It is far more likely that a user would want to specify a mixin as an argument to a command rather than utilize a mixin during the invocation of the 'alias' verb itself.