### PR TITLE
Use only the base name of the program in argparse help

### DIFF
--- a/colcon_alias/argument_parser/alias.py
+++ b/colcon_alias/argument_parser/alias.py
@@ -1,6 +1,8 @@
 # Copyright 2022 Scott K Logan
 # Licensed under the Apache License, Version 2.0
 
+import os
+
 from colcon_alias.config import get_config
 from colcon_alias.verb.alias_invocation import AliasInvocationVerb
 from colcon_core.argument_parser import ArgumentParserDecorator
@@ -66,11 +68,13 @@ class AliasArgumentDecorator(ArgumentParserDecorator):
         if self._done:
             return
 
+        prog = os.path.basename(self._parser.prog)
+
         add_args_now = False
         if not self._subparser:
             add_args_now = True
             self.add_subparsers(
-                title='colcon verbs', dest='verb_name')
+                title=prog + ' verbs', dest='verb_name')
 
         config = get_config()
         if not config:
@@ -105,7 +109,7 @@ class AliasArgumentDecorator(ArgumentParserDecorator):
             if add_args_now:
                 extension.add_arguments(parser=alias_parser)
 
-        epilog = self._parser.prog + ' aliases:\n' + '\n'.join(aliases)
+        epilog = prog + ' aliases:\n' + '\n'.join(aliases)
         if self._parser.epilog:
             self._parser.epilog = epilog + '\n\n' + self._parser.epilog
         else:


### PR DESCRIPTION
Showing the "full" program name where appropriate in some parts of the help output is useful, but in this context, we're really referring more to the program's title in a more abstract sense. Since we don't want to re-invoke `colcon_core.command.get_prog_name`, we can narrow our current use of the argparse reported prog to only the basename which will usually give us exactly what we want.

Example of where the full path was harming the help text experience:
<details>

```
usage: C:\Program Files\Python312\Scripts\colcon [-h] [--log-base LOG_BASE] [--log-level LOG_LEVEL]
                                                 {alias,build,extension-points,extensions,graph,info,list,metadata,mixin,rerun,test,test-result,version-check,bat}
                                                 ...

options:
  -h, --help            show this help message and exit
  --log-base LOG_BASE   The base path for all log directories (default: ./log, to disable: nul)
  --log-level LOG_LEVEL
                        Set log level for the console output, either by numeric or string value (default: warning)

colcon verbs:
  alias                 Create and modify command aliases
  build                 Build a set of packages
  extension-points      List extension points
  extensions            List extensions
  graph                 Generate a visual representation of the dependency graph
  info                  Package information
  list                  List packages, optionally in topological ordering
  metadata              Manage metadata of packages
  mixin                 Manage CLI mixins
  rerun                 Quickly re-run a recently executed verb
  test                  Test a set of packages
  test-result           Show the test results generated when testing a set of
                        packages
  version-check         Compare local package versions with PyPI

  {alias,build,extension-points,extensions,graph,info,list,metadata,mixin,rerun,test,test-result,version-check,bat}
                        call `colcon VERB -h` for specific help

C:\Program Files\Python312\Scripts\colcon aliases:
  bat                   rerun build
                        rerun test

Environment variables:
  CMAKE_COMMAND         The full path to the CMake executable
  COLCON_ALL_SHELLS     Flag to enable all shell extensions
  COLCON_DEFAULTS_FILE  Set path to the yaml file containing the default values
                        for the command line arguments (default:
                        $COLCON_HOME/defaults.yaml)
  COLCON_DEFAULT_EXECUTOR
                        Select the default executor extension
  COLCON_EXTENSION_BLOCKLIST
                        Block extensions which should not be used
  COLCON_HOME           Set the configuration directory (default: ~/.colcon)
  COLCON_LOG_LEVEL      Set the log level (debug|10, info|20, warn|30,
                        error|40, critical|50, or any other positive numeric
                        value)
  COLCON_MIXIN_PATH     Provide additional directories to look for mixin files.
                        Separate individual directories with colons.
  COLCON_WARNINGS       Set the warnings filter similar to PYTHONWARNINGS
                        except that the module entry is implicitly set to
                        'colcon.*'
  CTEST_COMMAND         The full path to the CTest executable
  POWERSHELL_COMMAND    The full path to the PowerShell executable

For more help and usage tips, see https://colcon.readthedocs.io
```

</details>