### PR TITLE
Suppress flake8 A005 in existing API

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -70,6 +70,8 @@ colcon_core.verb =
 
 [flake8]
 import-order-style = google
+per-file-ignores =
+    colcon_alias/logging.py:A005
 
 [coverage:run]
 source = colcon_alias


### PR DESCRIPTION
This is a new check, and addressing the check's concern would change the public API of the package. Suppress the existing violation specifically and continue using the check to prevent new code from violating the rule.