### PR TITLE
Use newly added colcon_core.logging.get_effective_console_level

### DIFF
--- a/colcon_alias/logging.py
+++ b/colcon_alias/logging.py
@@ -3,17 +3,10 @@
 
 import logging
 
-from colcon_core.logging import colcon_logger
-
-
-def _get_effective_log_level():
-    for handler in colcon_logger.handlers:
-        if isinstance(handler, logging.StreamHandler):
-            return handler.level
-    return logging.WARNING
+from colcon_core.logging import get_effective_console_level
 
 
 def configure_filelock_logger():
     """Configure the 'filelock' log level based on colcon's log level."""
-    log_level = _get_effective_log_level()
+    log_level = get_effective_console_level()
     logging.getLogger('filelock').setLevel(log_level)

--- a/colcon_alias/logging.py
+++ b/colcon_alias/logging.py
@@ -3,10 +3,11 @@
 
 import logging
 
+from colcon_core.logging import colcon_logger
 from colcon_core.logging import get_effective_console_level
 
 
 def configure_filelock_logger():
     """Configure the 'filelock' log level based on colcon's log level."""
-    log_level = get_effective_console_level()
+    log_level = get_effective_console_level(colcon_logger)
     logging.getLogger('filelock').setLevel(log_level)

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,7 @@ keywords = colcon
 [options]
 python_requires = >=3.6
 install_requires =
-  colcon-core
+  colcon-core>=0.17.0
   filelock
   PyYAML
 packages = find:

--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -1,6 +1,6 @@
 [colcon-alias]
 No-Python2:
-Depends3: python3-colcon-core, python3-filelock, python3-yaml
+Depends3: python3-colcon-core (>= 0.17.0), python3-filelock, python3-yaml
 Conflicts3: python3-colcon-mixin (< 0.2.2)
 Suite: focal jammy noble bookworm trixie
 X-Python3-Version: >= 3.6


### PR DESCRIPTION
The newly provided function replaces the private implementation carried here.

This PR should be updated to include the new version constraint when `colcon-core` is next released, so marking draft until then.