### PR TITLE
Explicitly return zero on success

### DIFF
--- a/colcon_alias/verb/alias.py
+++ b/colcon_alias/verb/alias.py
@@ -44,3 +44,4 @@ class AliasVerb(VerbExtensionPoint):
                 f"'{context.args.alias_name}':")
             for command in context.args.command:
                 print(f"  {' '.join(command)}")
+        return 0


### PR DESCRIPTION
Though 'None' is treated the same as '0' in this context, it aligns with the verbs in colcon-core to explicitly return 0 when the verb completes correctly.